### PR TITLE
Add a new widget for BART tracking

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -13,6 +13,10 @@ devs:
     route-number: 8
     stop-id: 5933
 
+  bart-tracker:
+    api-key: "MW9S-E7SL-26DU-VV8V"
+    station-id: "powl"
+
   clock:
     interval: 30
     order: 4

--- a/resources/public/css/main.css
+++ b/resources/public/css/main.css
@@ -508,6 +508,52 @@ div#plugins #cta-bus-tracker ul li span.time {
   float: right;
 }
 
+/* BART tracker styles */
+
+div#plugins #bart-tracker h3 {
+  padding-bottom: 10px;
+}
+
+div#plugins #bart-tracker div.departures {
+  clear: left;
+  height: 45px;
+}
+
+div#plugins #bart-tracker div.destination {
+  width: 225px;
+  float: left;
+  padding: 5px;
+}
+
+div#plugins #bart-tracker div.departure {
+  float: left;
+  padding: 2px;
+  border-width: 5px;
+  border-style: solid;
+  width: 95px;
+  margin-right: 5px;
+}
+
+div#plugins #bart-tracker .blue {
+  border-color: #0099cc;
+}
+
+div#plugins #bart-tracker .green {
+  border-color: #339933;
+}
+
+div#plugins #bart-tracker .yellow {
+  border-color: #ffff33;
+}
+
+div#plugins #bart-tracker .orange {
+  border-color: #ff9933;
+}
+
+div#plugins #bart-tracker .red {
+  border-color: #ff0000;
+}
+
 div#plugins .people {
   width: 100%;
   margin: 15px 0 0 0;

--- a/src/brainiac/plugins/bart_tracker.clj
+++ b/src/brainiac/plugins/bart_tracker.clj
@@ -1,0 +1,47 @@
+(ns brainiac.plugins.bart-tracker
+  (:require [brainiac.plugin :as brainiac]
+            [brainiac.xml-utils :as xml]
+            [clojure.contrib.zip-filter.xml :as zf]
+            [clojure.string :as string]))
+
+(defn advisory-url [api-key]
+  (format "http://api.bart.gov/api/bsa.aspx?cmd=bsa&key=%s&date=today" api-key))
+
+(defn schedule-url [station-id api-key]
+  (format "http://api.bart.gov/api/etd.aspx?cmd=etd&orig=%s&key=%s" station-id api-key))
+
+(defn minutes-display [minutes]
+  (if (= minutes "Leaving")
+    "now"
+    (str minutes "m")))
+
+(defn parse-estimate [node]
+  (let [minutes (zf/xml1-> node :minutes zf/text)
+        color (string/lower-case (zf/xml1-> node :color zf/text))
+        length (zf/xml1-> node :length zf/text)]
+    (assoc {}
+           :minutes (minutes-display minutes)
+           :color color
+           :length length)))
+
+(defn parse-departure [node]
+  (let [destination (zf/xml1-> node :destination zf/text)]
+    (assoc {}
+           :destination destination
+           :estimates (take 3 (zf/xml-> node :estimate parse-estimate)))))
+
+(defn transform-station [stream]
+  (let [xml-zipper (xml/parse-xml stream)
+        station (zf/xml1-> xml-zipper :station :name zf/text)]
+    (assoc {}
+           :name "bart-tracker"
+           :station station
+           :data (take 7 (zf/xml-> xml-zipper :station :etd parse-departure)))))
+
+(defn configure [{:keys [station-id api-key program-name]}]
+  (brainiac/schedule
+    20000
+    (brainiac/simple-http-plugin
+      {:method "GET" :url (schedule-url station-id api-key)}
+      transform-station program-name)))
+

--- a/src/brainiac/templates/bart-tracker.html
+++ b/src/brainiac/templates/bart-tracker.html
@@ -1,0 +1,10 @@
+<h3>BART {{station}} Departures</h3>
+
+{{#data}}
+<div class="departures">
+  <div class="destination">{{destination}}</div>
+  {{#estimates}}
+  <div class="departure {{color}}">{{minutes}} - {{length}}</div>
+  {{/estimates}}
+</div>
+{{/data}}


### PR DESCRIPTION
We're looking at spinning up a Brainiac instance for the SF office. Since CTA sadly does not server the Bay Area, I wrote a widget to track BART departures instead.

Please let me know what you think!

Thanks,
Gary Bramwell
