### PR TITLE
Make brainiac compatible with being served over HTTPS

### DIFF
--- a/resources/public/css/main.css
+++ b/resources/public/css/main.css
@@ -1,6 +1,6 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:600italic,600,800);
-@import url(http://fonts.googleapis.com/css?family=Aldrich);
-@import url(http://fonts.googleapis.com/css?family=Source+Code+Pro);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:600italic,600,800);
+@import url(https://fonts.googleapis.com/css?family=Aldrich);
+@import url(https://fonts.googleapis.com/css?family=Source+Code+Pro);
 
 .nocursor { cursor:none; }
 

--- a/resources/public/js/updater.js
+++ b/resources/public/js/updater.js
@@ -8,7 +8,7 @@ var Updater = (function() {
     },
 
     socket: function() {
-      new WebSocket("ws://" + location.host + "/async");
+      new WebSocket(('https:' == document.location.protocol ? 'wss://' : 'ws://') + location.host + "/async");
     },
 
     renderTemplate: function(name, data) {
@@ -76,7 +76,7 @@ var Updater = (function() {
 
     subscribe: function() {
       var self = this;
-      socket = new WebSocket("ws://" + location.host + "/async");
+      socket = new WebSocket(('https:' == document.location.protocol ? 'wss://' : 'ws://') + location.host + "/async");
       socket.onmessage = function (e) {
         self.update(e);
         self.startTimer();


### PR DESCRIPTION
- Change google font css to go over https
- Use wss:// instead of ws:// if brainiac was loaded over https

Tests are currently broken but are fixed in #41.
