### PR TITLE
Add Muni tracking widget

### DIFF
--- a/config.yml.example
+++ b/config.yml.example
@@ -58,6 +58,10 @@ devs:
     #username: "yourusername"
     #password: "yourpassword"
 
+  #muni-tracker:
+    #stop-id: 15237
+    #api-key: 511.ORG-API-KEY
+
   #jukebox:
     #order: 9
     #url: "http://url.example.com"

--- a/src/brainiac/plugins/muni_tracker.clj
+++ b/src/brainiac/plugins/muni_tracker.clj
@@ -1,0 +1,19 @@
+(ns brainiac.plugins.muni-tracker
+  (:require [brainiac.plugin :as brainiac]
+            [brainiac.xml-utils :as xml]
+            [clojure.contrib.zip-filter.xml :as zf]))
+
+(defn route-with-departures [route]
+  (assoc {}
+    :name (zf/xml1-> route (zf/attr :Name))
+    :direction (zf/xml1-> route :RouteDirectionList :RouteDirection (zf/attr :Name))
+    :departures (zf/xml-> route :RouteDirectionList :RouteDirection :StopList :Stop :DepartureTimeList :DepartureTime zf/text)))
+
+(defn transform [stream]
+  (let [xml-zipper (xml/parse-xml stream)
+        routes (zf/xml-> xml-zipper :AgencyList :Agency :RouteList :Route route-with-departures)
+        stop (zf/xml1-> xml-zipper :AgencyList :Agency :RouteList :Route :RouteDirectionList :RouteDirection :StopList :Stop (zf/attr :name))]
+    (assoc {}
+      :name "muni-tracker"
+      :stop stop
+      :routes routes)))

--- a/src/brainiac/plugins/muni_tracker.clj
+++ b/src/brainiac/plugins/muni_tracker.clj
@@ -9,11 +9,25 @@
     :direction (zf/xml1-> route :RouteDirectionList :RouteDirection (zf/attr :Name))
     :departures (zf/xml-> route :RouteDirectionList :RouteDirection :StopList :Stop :DepartureTimeList :DepartureTime zf/text)))
 
+(defn has-departures? [route]
+  (seq (:departures route)))
+
 (defn transform [stream]
   (let [xml-zipper (xml/parse-xml stream)
-        routes (zf/xml-> xml-zipper :AgencyList :Agency :RouteList :Route route-with-departures)
+        routes (filter has-departures? (zf/xml-> xml-zipper :AgencyList :Agency :RouteList :Route route-with-departures))
         stop (zf/xml1-> xml-zipper :AgencyList :Agency :RouteList :Route :RouteDirectionList :RouteDirection :StopList :Stop (zf/attr :name))]
     (assoc {}
       :name "muni-tracker"
       :stop stop
       :routes routes)))
+
+(defn url [api-key stop-id]
+  (format "http://services.my511.org/Transit2.0/GetNextDeparturesByStopCode.aspx?token=%s&stopcode=%s" api-key stop-id))
+
+(defn configure [{:keys [api-key stop-id program-name]}]
+  (brainiac/schedule
+    20000
+    (brainiac/simple-http-plugin
+      {:method "GET" :url (url api-key stop-id)}
+      transform program-name)))
+

--- a/src/brainiac/templates/muni-tracker.html
+++ b/src/brainiac/templates/muni-tracker.html
@@ -1,0 +1,10 @@
+<h3>{{stop}}</h3>
+
+{{#routes}}
+  <h4>{{name}}: {{direction}}</h4>
+  <ul><li>
+  {{#departures}}
+    <span class="time">{{.}}</span> minutes
+  {{/departures}}
+  </ul></li>
+{{/routes}}

--- a/test/brainiac/test/data/muni_stop.xml
+++ b/test/brainiac/test/data/muni_stop.xml
@@ -1,0 +1,47 @@
+
+<RTT>
+<AgencyList>
+<Agency Name="SF-MUNI" HasDirection="True" Mode="Bus">
+<RouteList>
+<Route Name="30-Stockton" Code="30">
+<RouteDirectionList>
+<RouteDirection Code="Outbound" Name="Outbound to The Marina District">
+<StopList>
+<Stop name="Townsend and 4th" StopCode="17235">
+<DepartureTimeList>
+<DepartureTime>5</DepartureTime>
+<DepartureTime>8</DepartureTime>
+<DepartureTime>11</DepartureTime>
+</DepartureTimeList>
+</Stop>
+
+</StopList>
+</RouteDirection>
+
+</RouteDirectionList>
+</Route>
+
+<Route Name="45-Union Stockton" Code="45">
+<RouteDirectionList>
+<RouteDirection Code="Outbound" Name="Outbound to The Presidio">
+<StopList>
+<Stop name="Townsend and 4th" StopCode="17235">
+<DepartureTimeList>
+<DepartureTime>2</DepartureTime>
+<DepartureTime>14</DepartureTime>
+<DepartureTime>27</DepartureTime>
+</DepartureTimeList>
+</Stop>
+
+</StopList>
+</RouteDirection>
+
+</RouteDirectionList>
+</Route>
+
+</RouteList>
+</Agency>
+
+</AgencyList>
+</RTT>
+

--- a/test/brainiac/test/data/muni_stop.xml
+++ b/test/brainiac/test/data/muni_stop.xml
@@ -3,6 +3,17 @@
 <AgencyList>
 <Agency Name="SF-MUNI" HasDirection="True" Mode="Bus">
 <RouteList>
+<Route Name="Embarcadero" Code="E">
+<RouteDirectionList>
+<RouteDirection Code="Outbound" Name="Outbound to King and 4th">
+<StopList>
+<Stop name="Townsend and 4th" StopCode="17235">
+  <DepartureTimeList/>
+</Stop>
+</StopList>
+</RouteDirection>
+</RouteDirectionList>
+</Route>
 <Route Name="30-Stockton" Code="30">
 <RouteDirectionList>
 <RouteDirection Code="Outbound" Name="Outbound to The Marina District">

--- a/test/brainiac/test/plugins/muni_tracker.clj
+++ b/test/brainiac/test/plugins/muni_tracker.clj
@@ -1,0 +1,22 @@
+(ns brainiac.test.plugins.muni-tracker
+  (:use [brainiac.plugins.muni-tracker]
+        [clojure.test]
+        [clojure.contrib.mock]))
+
+(def sample-stop (java.io.ByteArrayInputStream. (.getBytes (slurp "test/brainiac/test/data/muni_stop.xml"))))
+
+(deftest test-transform
+  (let [result (transform sample-stop)]
+    (testing "sets routes with direction"
+      (is (= ["30-Stockton"
+              "45-Union Stockton"] (map :name (:routes result)))))
+
+    (testing "sets routes with direction"
+      (is (= ["Outbound to The Marina District"
+              "Outbound to The Presidio"] (map :direction (:routes result)))))
+    
+    (testing "sets stop name"
+      (is (= "Townsend and 4th" (:stop result))))
+
+    (testing "sets departure times for a route"
+      (is (= '("5" "8" "11") (:departures (first (:routes result))))))))


### PR DESCRIPTION
While specifically meant for SF MUNI, the plugin should work for any transit system available via 511.org.
